### PR TITLE
improve update-script:

### DIFF
--- a/github.py
+++ b/github.py
@@ -12,10 +12,10 @@ class GithubRoutes:
 
     def on_post(self, req: falcon.Request, resp: falcon.Response):
         hub_signature = req.get_header(
-                "x-hub-signature-256",
-                required=True,
-                default="x-hub-signature-256 is missing"
-                )
+            "x-hub-signature-256",
+            required=True,
+            default="x-hub-signature-256 is missing"
+        )
 
         with req.bounded_stream as rs:
             raw_body = rs.read()
@@ -23,8 +23,8 @@ class GithubRoutes:
         expected_signature = f"sha256={digest.hexdigest()}"
         if not hmac.compare_digest(expected_signature, hub_signature):
             raise falcon.HTTPBadRequest(
-                    title="Signature unmatched",
-                    description="Calculated and provided signature didn't match"
-                    )
+                title="Signature unmatched",
+                description="Calculated and provided signature didn't match"
+            )
         path = os.path.dirname(os.path.realpath(__file__))
         subprocess.Popen(["sh", f"{path}/update_api.sh", path, self.service_name])

--- a/github.py
+++ b/github.py
@@ -4,11 +4,19 @@ import hmac
 import os
 import subprocess
 
+own_dir = os.path.dirname(__file__)
+
 
 class GithubRoutes:
-    def __init__(self, webhook_secret: str, service_name: str):
+    def __init__(
+        self,
+        webhook_secret: str,
+        service_name: str,
+        update_script_path: str=os.path.join(own_dir, 'update_api.sh'),
+    ):
         self.webhook_secret = webhook_secret.encode("utf-8")
         self.service_name = service_name
+        self.update_script_path = update_script_path
 
     def on_post(self, req: falcon.Request, resp: falcon.Response):
         hub_signature = req.get_header(
@@ -26,5 +34,4 @@ class GithubRoutes:
                 title="Signature unmatched",
                 description="Calculated and provided signature didn't match"
             )
-        path = os.path.dirname(os.path.realpath(__file__))
-        subprocess.Popen(["sh", f"{path}/update_api.sh", path, self.service_name])
+        subprocess.Popen([self.update_script_path, self.service_name])

--- a/update_api.sh
+++ b/update_api.sh
@@ -1,5 +1,14 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
-cd $1
-git pull origin master --rebase
-sudo systemctl restart $2
+own_dir="$(dirname "${BASH_SOURCE[0]}")"
+
+# usage:
+# update_api.sh <systemd-unit-name>
+
+set -euo pipefail
+
+git \
+  -C "${own_dir}" \
+  pull origin master --rebase
+
+sudo systemctl restart "${1}"


### PR DESCRIPTION
- use env (do not hardcode path to bash)
- calculate path to self (drop necessity to pass via ARGV)
- avoid chdir prior to calling git